### PR TITLE
update CURRENT_KAFKA_VERSION and CURRENT_MESSAGE_FORMAT_VERSION

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ ENV KAFKA_PORT=9092 \
     PROMETHEUS_JMX_ENABLE=false \
     ENTRYPOINTS_DIR=/opt/qnib/entry \
     ZK_SERVERS=tasks.zookeeper \
-    INTER_BROKER_PROTOCOL_VERSION=1.0-IV0 \
-    LOG_MESSAGE_FORMAT_VERSION=${KAFKA_VER} \
+    INTER_BROKER_PROTOCOL_VERSION=1.0 \
+    LOG_MESSAGE_FORMAT_VERSION=1.0 \
     KAFKA_ID_OFFSET=0
 RUN apk --no-cache add curl bc \
  && mkdir -p /opt/kafka \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV KAFKA_PORT=9092 \
     ENTRYPOINTS_DIR=/opt/qnib/entry \
     ZK_SERVERS=tasks.zookeeper \
     INTER_BROKER_PROTOCOL_VERSION=1.0-IV0 \
-    LOG_MESSAGE_FORMAT_VERSION=CURRENT_KAFKA_VERSION \
+    LOG_MESSAGE_FORMAT_VERSION=${KAFKA_VER} \
     KAFKA_ID_OFFSET=0
 RUN apk --no-cache add curl bc \
  && mkdir -p /opt/kafka \


### PR DESCRIPTION
refers to https://kafka.apache.org/documentation/
1.5 Upgrading From Previous Versions
Upgrading from 0.8.x, 0.9.x, 0.10.0.x, 0.10.1.x, 0.10.2.x or 0.11.0.x to 1.0.0
Kafka 1.0.0 introduces wire protocol changes. By following the recommended rolling upgrade plan below, you guarantee no downtime during the upgrade. However, please review the notable changes in 1.0.0 before upgrading.

For a rolling upgrade:

Update server.properties on all brokers and add the following properties. CURRENT_KAFKA_VERSION refers to the version you are upgrading from. CURRENT_MESSAGE_FORMAT_VERSION refers to the message format version currently in use. If you have previously overridden the message format version, you should keep its current value. Alternatively, if you are upgrading from a version prior to 0.11.0.x, then CURRENT_MESSAGE_FORMAT_VERSION should be set to match CURRENT_KAFKA_VERSION.
inter.broker.protocol.version=CURRENT_KAFKA_VERSION (e.g. 0.8.2, 0.9.0, 0.10.0, 0.10.1, 0.10.2, 0.11.0).
log.message.format.version=CURRENT_MESSAGE_FORMAT_VERSION (See potential performance impact following the upgrade for the details on what this configuration does.)
If you are upgrading from 0.11.0.x and you have not overridden the message format, then you only need to override the inter-broker protocol format.
inter.broker.protocol.version=CURRENT_KAFKA_VERSION (e.g. 0.8.2, 0.9.0, 0.10.0, 0.10.1, 0.10.2, 0.11.0).
Upgrade the brokers one at a time: shut down the broker, update the code, and restart it.
Once the entire cluster is upgraded, bump the protocol version by editing inter.broker.protocol.version and setting it to 1.0.
Restart the brokers one by one for the new protocol version to take effect.